### PR TITLE
msm: crypto: Fix integer over flow check in qcrypto driver

### DIFF
--- a/drivers/crypto/msm/qcrypto.c
+++ b/drivers/crypto/msm/qcrypto.c
@@ -1771,12 +1771,12 @@ static int _qcrypto_process_aead(struct  crypto_engine *pengine,
 			 * include  assoicated data, ciphering data stream,
 			 * generated MAC, and CCM padding.
 			 */
-			if ((MAX_ALIGN_SIZE * 2 > ULONG_MAX - req->assoclen) ||
+			if ((MAX_ALIGN_SIZE * 2 > UINT_MAX - req->assoclen) ||
 				((MAX_ALIGN_SIZE * 2 + req->assoclen) >
-						ULONG_MAX - qreq.ivsize) ||
+						UINT_MAX - qreq.ivsize) ||
 				((MAX_ALIGN_SIZE * 2 + req->assoclen
 					+ qreq.ivsize)
-						> ULONG_MAX - req->cryptlen)) {
+						> UINT_MAX - req->cryptlen)) {
 				pr_err("Integer overflow on aead req length.\n");
 				return -EINVAL;
 			}


### PR DESCRIPTION
Integer overflow check is invalid when ULONG_MAX is used,
as ULONG_MAX has typeof 'unsigned long', while req->assoclen,
req->crytlen, and qreq.ivsize are 'unsigned int'. Make change
to use UINT_MAX instead of ULONG_MAX.

Change-Id: I76c531a2b9256ebff64d6de0234e5fc7a4250187
CRs-fixed: 1050970
Signed-off-by: Zhen Kong <zkong@codeaurora.org>
(cherry picked from commit 9bd7915dae787f35ab3be0d02ceccf72d1d292e4)